### PR TITLE
Handle SOLR 6 and situations with unknown solr hostnames

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,6 @@
 import mock
 from wukong.api import SolrAPI
 from wukong.errors import *
-import pytest
 import json
 
 try:
@@ -45,8 +44,7 @@ class TestSolrAPI(unittest.TestCase):
         with self.assertRaises(SolrError) as cm:
             SolrAPI(
                 None,
-                "test_collection",
-                "localzook01:2181,localzook02:2181"
+                "test_collection"
             )
 
         solr_error = cm.exception

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -62,6 +62,15 @@ class TestSolrAPI(unittest.TestCase):
         assert api.solr_collection == "test_collection"
         assert api.zookeeper_hosts == None
 
+    def test_api_constructor__only_zook_host(self):
+        api = SolrAPI(
+            None,
+            'test_collection',
+            'localzook:2181,localzook:2182/solr'
+        )
+
+        self.assertIsNotNone(api.solr_hosts)
+
     def test_api_constructor__error_no_collection(self):
         with self.assertRaises(SolrError) as cm:
             SolrAPI(

--- a/tests/test_zookeeper.py
+++ b/tests/test_zookeeper.py
@@ -13,7 +13,7 @@ class TestZookeeper(unittest.TestCase):
     zook_client = Zookeeper("http://localzook01:2181,http://localzook02:2181")
 
     @patch('kazoo.client.KazooClient')
-    def test_valid_clustersate_file(self, mock_kazoo):
+    def test_valid_clusterstate_file(self, mock_kazoo):
 
         class MockKazoo(object):
             def __init__(self):
@@ -21,6 +21,9 @@ class TestZookeeper(unittest.TestCase):
 
             def start(self, *args, **kwargs):
                 return True
+
+            def get_children(self, *args, **kwargs):
+                return ['acsvc_test_collection']
 
             def get(self, *args, **kwargs):
                 return ('{\n  "acsvc_test_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"acsvc_test_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"},\n          "core_node2":{\n            "state":"active",\n            "core":"acsvc_test_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "psvc_test_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"psvc_test_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"},\n          "core_node2":{\n            "state":"active",\n            "core":"psvc_test_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "bm_solr_entity_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"bm_solr_entity_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"},\n          "core_node2":{\n            "state":"active",\n            "core":"bm_solr_entity_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "qb_category_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"qb_category_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"},\n          "core_node2":{\n            "state":"active",\n            "core":"qb_category_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "mt3_qb_category_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"mt3_qb_category_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"},\n          "core_node2":{\n            "state":"active",\n            "core":"mt3_qb_category_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "mt3_qb_question_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"mt3_qb_question_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"},\n          "core_node2":{\n            "state":"active",\n            "core":"mt3_qb_question_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "mt2_qb_category_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"mt2_qb_category_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"},\n          "core_node2":{\n            "state":"active",\n            "core":"mt2_qb_category_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "mt2_qb_question_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"mt2_qb_question_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"},\n          "core_node2":{\n            "state":"active",\n            "core":"mt2_qb_question_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"},\n  "qb_question_test_collection":{\n    "shards":{"shard1":{\n        "range":"80000000-7fffffff",\n        "state":"active",\n        "replicas":{\n          "core_node1":{\n            "state":"active",\n            "core":"qb_question_test_collection_shard1_replica2",\n            "node_name":"mt3-bmsolr101:8080_solr",\n            "base_url":"http://mt3-bmsolr101:8080/solr",\n            "leader":"true"},\n          "core_node2":{\n            "state":"active",\n            "core":"qb_question_test_collection_shard1_replica1",\n            "node_name":"mt3-bmsolr102:8080_solr",\n            "base_url":"http://mt3-bmsolr102:8080/solr"}}}},\n    "maxShardsPerNode":"1",\n    "router":{"name":"compositeId"},\n    "replicationFactor":"2",\n    "autoAddReplicas":"false"}}', )
@@ -35,7 +38,7 @@ class TestZookeeper(unittest.TestCase):
                           u'http://mt3-bmsolr101:8080'].sort())
 
     @patch('kazoo.client.KazooClient')
-    def test_no_clustersate_file(self, mock_kazoo):
+    def test_no_clusterstate_file(self, mock_kazoo):
 
         class MockKazoo(object):
             def __init__(self):
@@ -43,6 +46,9 @@ class TestZookeeper(unittest.TestCase):
 
             def start(self, *args, **kwargs):
                 return True
+
+            def get_children(self, *args, **kwargs):
+                return []
 
             def get(self, *args, **kwargs):
                 return None
@@ -63,6 +69,9 @@ class TestZookeeper(unittest.TestCase):
 
             def start(self, *args, **kwargs):
                 raise requests.exceptions.ConnectionError
+
+            def get_children(self, *args, **kwargs):
+                return []
 
             def get(self, *args, **kwargs):
                 return None

--- a/wukong/zookeeper.py
+++ b/wukong/zookeeper.py
@@ -1,5 +1,30 @@
 import kazoo.client
+from kazoo.exceptions import NoNodeError
 import json
+from collections import defaultdict
+import itertools
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def _get_hosts_from_state(state):
+    """
+    Given a SOLR state json blob, extract the active hosts
+
+    :param state dict: SOLR state blob
+    :returns: list[str]
+    """
+    active_nodes = set()
+    for shard, shard_data in state['shards'].items():
+        replicas = shard_data['replicas']
+        for replica, replica_data in replicas.items():
+            if replica_data['state'] == 'active':
+                node_url = replica_data['base_url'][:-5]  # strip /solr
+                node_url = node_url.replace('http://', '')
+                active_nodes.add(node_url)
+
+    return active_nodes
 
 
 class Zookeeper(object):
@@ -9,10 +34,9 @@ class Zookeeper(object):
     def __init__(self, hosts):
         self.hosts = hosts
 
-    def get_active_hosts(self):
-        """
-        Get the current active SOLR hosts from Zookeeper
-        """
+    def _get_active_hosts(self):
+        active_hosts = defaultdict(set)
+
         try:
             zk_client = kazoo.client.KazooClient(
                 hosts=self.hosts,
@@ -20,8 +44,32 @@ class Zookeeper(object):
             )
             zk_client.start(timeout=5)
         except Exception:
-            return []
+            return active_hosts
 
+        try:
+            collections = zk_client.get_children('/collections')
+        except NoNodeError:
+            # No collections have been created on the zookeeper host yet.
+            collections = []
+
+        # Handle SOLR 6+ style state.json paths
+        for collection in collections:
+            try:
+                state_path = '/collections/{}/state.json'.format(collection)
+                state_json = zk_client.get(state_path)[0]
+            except NoNodeError:
+                logger.debug(
+                    'No SOLR 6 state found for collection [%s]',
+                    collection
+                )
+            else:
+                state = json.loads(state_json)
+
+                active_hosts[collection] |= _get_hosts_from_state(
+                    state.get(collection, {})
+                )
+
+        # Handle SOLR <6 style clusterstate.json
         try:
             cluster_state_str = zk_client.get('/clusterstate.json')[0]
         except Exception:
@@ -29,16 +77,30 @@ class Zookeeper(object):
 
         cluster_state = json.loads(cluster_state_str)
 
-        active_nodes = set()
-        for collection in cluster_state:
-            for shard, shard_data in cluster_state[collection]['shards']\
-                    .items():
-                for replica, replica_data in shard_data['replicas']\
-                        .items():
-                    if replica_data['state'] == 'active':
-                        node_url = replica_data['base_url'][:-5]
-                        active_nodes.add(node_url)
+        for collection_name, state in cluster_state.items():
+            hosts = _get_hosts_from_state(state)
+            active_hosts[collection_name] |= hosts
 
         zk_client.stop()
 
-        return list(active_nodes)
+        return active_hosts
+
+    def get_active_hosts(self, collection_name=None):
+        """
+        Get the current active SOLR hosts from Zookeeper
+
+        :param collection_name: If provided, the name of a SOLR collection to
+                                get the hosts for. If not provided, all solr
+                                hosts will be returned.
+                                Optional.
+
+        :returns list[str]: A list of solr nodes in the form `http://hostname`
+        """
+        active_hosts = self._get_active_hosts()
+
+        if collection_name is not None:
+            return list(active_hosts.get(collection_name, []))
+        else:
+            return list(itertools.chain.from_iterable(
+                self._get_active_hosts().values()
+            ))


### PR DESCRIPTION
@dkuang1980 

Refactored a bit to allow for scenarios where the solr hosts are only known to zookeeper, and to enable fetching the state from solr 6 style `/collections/collection_name/state.json` vs solr < 6 style `/clusterstate.json`
