### PR TITLE
Decode the response from zookeeper when checking for available hosts (Fixes #5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - TOXENV=py33
   - TOXENV=py34
   - TOXENV=pypy
-  - TOXENV=pypy3
   - TOXENV=flake8
 install:
   - travis_retry pip install python-coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = py27, pypy, py33, py34, pypy3, flake8
+envlist = py27, pypy, py33, py34, flake8
 
 [testenv]
 usedevelop = true

--- a/wukong/zookeeper.py
+++ b/wukong/zookeeper.py
@@ -63,6 +63,9 @@ class Zookeeper(object):
                     collection
                 )
             else:
+                if not isinstance(state_json, str):
+                    state_json = state_json.decode('utf-8')
+
                 state = json.loads(state_json)
 
                 active_hosts[collection] |= _get_hosts_from_state(
@@ -74,6 +77,9 @@ class Zookeeper(object):
             cluster_state_str = zk_client.get('/clusterstate.json')[0]
         except Exception:
             cluster_state_str = '{}'
+
+        if not isinstance(cluster_state_str, str):
+            cluster_state_str = cluster_state_str.decode('utf-8')
 
         cluster_state = json.loads(cluster_state_str)
 


### PR DESCRIPTION
@dkuang1980 

After the fix:

```
Python 2.7.10 (default, Sep 23 2015, 04:34:21)
[GCC 4.2.1 Compatible Apple LLVM 7.0.0 (clang-700.0.72)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from wukong.models import SolrDoc
>>> class GroupMember(SolrDoc):
...     collection_name = 'group_members'
...     unique_key = 'group_member_id'
...     zookeeper_hosts = 'totally_real_zookeeper_host_list'
...
>>> GroupMember.documents.limit(10).all()
SolrDocs(len(GroupMember)=10)
```

```
Python 3.5.1 (default, May 19 2016, 04:03:38)
[GCC 4.2.1 Compatible Apple LLVM 7.3.0 (clang-703.0.31)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from wukong.models import SolrDoc
>>> class GroupMember(SolrDoc):
...     collection_name = 'group_members'
...     unique_key = 'group_member_id'
...     zookeeper_hosts = 'totally_real_zookeeper_host_list'
...
>>> GroupMember.documents.limit(10).all()
SolrDocs(len(GroupMember)=10)
```