### PR TITLE
Simplify the method of making requests, and add logging so it's more visible what's happening

### DIFF
--- a/wukong/request.py
+++ b/wukong/request.py
@@ -1,3 +1,5 @@
+import logging
+
 from wukong.zookeeper import Zookeeper
 from requests.exceptions import ConnectionError
 from wukong.errors import SolrError
@@ -11,6 +13,7 @@ try:
 except:
     from urllib.parse import urljoin
 
+logger = logging.getLogger()
 
 def process_response(response):
     if response.status_code != 200:
@@ -18,6 +21,7 @@ def process_response(response):
     try:
         response_content = json.loads(response.text)
     except:
+        logger.exception('Failed to parse solr text')
         raise SolrError("Parsing Error: %s" % response.text)
 
     return response_content
@@ -30,102 +34,109 @@ class SolrRequest(object):
     def __init__(self, solr_hosts, zookeeper_hosts=None, timeout=15):
         self.client = requests.Session()
         self.master_hosts = solr_hosts
-        self.current_hosts = solr_hosts
         self.servers = []
         self.timeout = timeout
-        if zookeeper_hosts is not None:
-            self.zookeeper = Zookeeper(zookeeper_hosts)
-        else:
-            self.zookeeper = None
 
         self.last_error = None
         # time to revert to old host list (in minutes) after an error
         self.check_hosts = 5
 
-    def request(self, path, params, method, body=None):
+        if zookeeper_hosts is not None:
+            logger.debug('Fetching solr from zookeeper')
+            self.zookeeper = Zookeeper(zookeeper_hosts)
+            self.master_hosts = self.zookeeper.get_active_hosts()
+            logger.info(
+                'Got solr nodes from zookeeper: %s',
+                ','.join(self.master_hosts)
+            )
+        else:
+            self.zookeeper = None
+
+        if not self.master_hosts:
+            logger.error('Unable to find any solr nodes to make requests to')
+            raise SolrError("SOLR reporting all nodes as down")
+
+        self.current_hosts = self.master_hosts  # Backwards Compat
+
+
+    def request(self, path, params, method, body=None, headers=None):
         """
         Prepare data and send request to SOLR servers
         """
-        def handle_error():
-            # if the sdk knows where zookeeper lives
-            if self.zookeeper is not None:
-                self.last_error = time.time()
-                # get the current list of active nodes from zookeeper
-                curr_hosts = self.zookeeper.get_active_hosts()
-                if len(curr_hosts) == 0:
-                    # all nodes are down - so raise an error
-                    raise SolrError("SOLR reporting all nodes as down")
-                else:
-                    # if all nodes are not down, update the current_hosts list
-                    # and the servers list
-                    self.current_hosts = curr_hosts
-                    self.servers = curr_hosts
+        request_headers = {
+            'content-type': 'application/json',
+        }
+        if headers:
+            request_headers.update(headers)
 
-            host = self.servers.pop(0)
-            return make_request(host, path)
 
-        headers = {'content-type': 'application/json'}
-        resultparams = {'wt': 'json',
-                        'omitHeader': 'true',
-                        'json.nl': 'map'}
-
-        if params is not None:
-            resultparams.update(params)
-
-        # if there hasn't been an error in 5 minutes, reset the solr_hosts
-        if self.last_error is not None and \
-                (time.time() - self.last_error) % 60 > self.check_hosts:
-
-            self.current_hosts = self.master_hosts
-            self.last_error = None
-
-        def make_request(host, path):
-            fullpath = urljoin(host, path)
+        request_params = {
+            'wt': 'json',
+            'omitHeader': True,
+            'json.nl': 'map'
+        }
+        if params:
+            request_params.update(params)
+        
+        response = None
+        for host in self.master_hosts:
+            full_path = urljoin(host, path)
             try:
+                logger.debug(
+                    'Sending request to solr. host="%s" path="%s"',
+                    host,
+                    path
+                )
+
                 response = self.client.request(
                     method,
-                    fullpath,
-                    params=resultparams,
-                    headers=headers,
+                    full_path,
+                    params=request_params,
+                    headers=request_headers,
                     data=body,
                     timeout=self.timeout
                 )
 
-                # Connected to the node, but didn't get a successful response
-                if (len(self.servers) > 0 and
-                        hasattr(response, 'status_code') and
-                        response.status_code != 200):
-                    # try with another node
-                    handle_error()
+                logger.debug(
+                    'Retrieved response from SOLR. host="%s" path="%s" '
+                    'status_code="%s"',
+                    host,
+                    path,
+                    response.status_code
+                )
 
-                return response
+                if response.status_code == 200:
+                    # We've had a successful request. No need to keep trying
+                    break
+                else:
+                    logger.info(
+                        'Unsucessful request to SOLR'
+                        'status_code="%s" reason="%s"',
+                        response.status_code,
+                        response.reason
+                    )
+                    response = None
 
-            # Didn't successfully connect to the node
-            except ConnectionError as e:
-                if len(self.servers) > 0:
-                    # try with another node
-                    handle_error()
+            except ConnectionError:
+                response = None
+                logger.info(
+                    'Failed to connect to SOLR',
+                    exc_info=True
+                )
 
-                raise SolrError(str(e))
+        if not response:
+            raise SolrError('Unable to fetch from any SOLR nodes')
 
-        self.servers = list(self.current_hosts)
-        if len(self.servers) == 0:
-            handle_error()
-
-        random.shuffle(self.servers)
-        host = self.servers.pop(0)
-
-        response = make_request(host, path)
         return process_response(response)
 
-    def post(self, path, params=None, body=None):
+    def post(self, path, params=None, body=None, headers=None):
         """
         Send a POST request to the SOLR servers
         """
-        return self.request(path, params, 'POST', body=body)
+        return self.request(path, params, 'POST', body=body, headers=headers)
 
-    def get(self, path, params=None):
+    def get(self, path, params=None, headers=None):
         """
         Send a GET request to the SOLR servers
         """
-        return self.request(path, params, 'GET')
+        return self.request(path, params, 'GET', headers=headers)


### PR DESCRIPTION
Spent a solid hour today trying to follow the logic flow here, so I drastically simplified it.

I believe the only feature I removed was that there's no longer a 5 minute timeout before retrying a failed host. In practice, I've mostly seen this in small network hiccups where 5 minutes means all nodes get marked down and then all requests fail because of a 3 second network failure.

SolrCloud should be able to manage it's own set of up/down nodes, so let's rely on that.