### PR TITLE
Make sure a scheme is always on the solr request

### DIFF
--- a/wukong/api.py
+++ b/wukong/api.py
@@ -7,6 +7,14 @@ import json
 
 logger = logging.getLogger(__name__)
 
+def _add_scheme_if_not_there(url, scheme='http'):
+    if not (
+        url.startswith('http://')
+        or url.startswith('https://')
+    ):
+        url = '{}://{}'.format(scheme, url)
+
+    return url
 
 class SolrAPI(object):
 
@@ -73,7 +81,11 @@ class SolrAPI(object):
             self.zookeeper_hosts = None
 
         logger.info('Connected to solr hosts %s', solr_hosts)
-        self.solr_hosts = ["http://%s/solr/" % host for host in solr_hosts]
+
+        self.solr_hosts = [
+            "{}/solr/".format(_add_scheme_if_not_there(host))
+            for host in solr_hosts
+        ]
 
         self.solr_collection = solr_collection
 

--- a/wukong/request.py
+++ b/wukong/request.py
@@ -74,7 +74,7 @@ class SolrRequest(object):
 
     def attempt_zookeeper_refresh(self):
         if self.zookeeper:
-            logger.debug('Fetching solr from zookeeper')
+            logger.debug('Fetching solr hosts from zookeeper')
             try:
                 self.master_hosts = self.zookeeper.get_active_hosts()
                 logger.info(
@@ -118,13 +118,9 @@ class SolrRequest(object):
 
         response = None
         for host in random.sample(self.master_hosts, len(self.master_hosts)):
-            full_path = urljoin(host, path)
+            full_path = '/'.join(s.strip('/') for s in [host, path])
             try:
-                logger.debug(
-                    'Sending request to solr. host="%s" path="%s"',
-                    host,
-                    path
-                )
+                logger.debug('Sending request to solr. route="%s"', full_path)
 
                 self._last_request = time.time()
 
@@ -138,10 +134,8 @@ class SolrRequest(object):
                 )
 
                 logger.debug(
-                    'Retrieved response from SOLR. host="%s" path="%s" '
-                    'status_code="%s"',
-                    host,
-                    path,
+                    'Retrieved response from SOLR. route="%s" status_code="%s"',
+                    full_path,
                     response.status_code
                 )
 

--- a/wukong/zookeeper.py
+++ b/wukong/zookeeper.py
@@ -20,9 +20,7 @@ def _get_hosts_from_state(state):
         replicas = shard_data['replicas']
         for replica, replica_data in replicas.items():
             if replica_data['state'] == 'active':
-                node_url = replica_data['base_url'][:-5]  # strip /solr
-                node_url = node_url.replace('http://', '')
-                active_nodes.add(node_url)
+                active_nodes.add(replica_data['base_url'])
 
     return active_nodes
 
@@ -129,6 +127,6 @@ class Zookeeper(object):
         if collection_name is not None:
             return list(active_hosts.get(collection_name, []))
         else:
-            return list(itertools.chain.from_iterable(
-                self._get_active_hosts().values()
-            ))
+            return list(set(itertools.chain.from_iterable(
+                active_hosts.values()
+            )))


### PR DESCRIPTION
It feels like this scheme stuff is becoming a recurring theme in my life.

The problem here was showing itself here: https://github.com/SurveyMonkey/wukong/blob/master/wukong/request.py#L109

turns out,
```py
joined = urljoin('solr_host:8983/solr', 'collections/collection_1')
joined != 'solr_host:8983/solr/collections/collection_1'
joined == 'collections/collection_1'

joined = urljoin('http://solr_host:8983/solr', 'collections/collection_1')
joined == 'http://solr_host:8983/solr/collections/collection_1'
```

I think this was only occuring on some of the requests because of some "redundancy" in how we compute these solr host names between zookeeper, specified directly, and refreshing from zookeeper. I want to look in to that overall but I think to do it cleanly will be a larger set of work than I want to jump on right now, so quick patch it is.