### PR TITLE
Use POST for /select API calls to avoid exceeding max uri length limits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,10 @@
 sudo: false
 language: python
 python:
-  - "2.7"
-  - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy"
+  - "3.7"
+  - "3.8"
   - "pypy3"
 install:
   - travis_retry pip install python-coveralls

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,9 @@
 
 #Release Notes
 
-0.5.2
+1.0.0
 ==========
+- Removed support for Python versions < 3.5 and pypy
 - Use POST instead of GET for /select API calls in order to avoid
   exceeding the max uri length for long queries (#26)
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 
 #Release Notes
 
+0.5.2
+==========
+- Use POST instead of GET for /select API calls in order to avoid
+  exceeding the max uri length for long queries (#26)
+
 0.5.1
 ==========
 - Only add /solr/ to the end of a solr url if it isn't already there

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     README = read('README.md')
     CHANGES = read('CHANGES.md')
 
-version = '0.5.1'
+version = '0.5.2'
 
 setup(
     name="wukong",

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     README = read('README.md')
     CHANGES = read('CHANGES.md')
 
-version = '0.5.2'
+version = '1.0.0'
 
 setup(
     name="wukong",
@@ -37,5 +37,10 @@ setup(
         "Natural Language :: English",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
+        "Programming Language :: Python :: 3 :: Only",
+        "Programming Language :: Python :: 3.5"
+        "Programming Language :: Python :: 3.6"
+        "Programming Language :: Python :: 3.7"
+        "Programming Language :: Python :: 3.8"
     ],
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -117,7 +117,7 @@ class TestSolrAPI(unittest.TestCase):
             assert not mock_method.called
 
     def test_api_select(self):
-        with mock.patch('wukong.request.SolrRequest.get') as mock_method:
+        with mock.patch('wukong.request.SolrRequest.post') as mock_method:
             fake_response = {
                 "response":{
                     "docs":[
@@ -148,7 +148,7 @@ class TestSolrAPI(unittest.TestCase):
             self.assertEqual(result['docs'][0]["test_field"], "Test Value")
 
     def test_api_select__group_by(self):
-        with mock.patch('wukong.request.SolrRequest.get') as mock_method:
+        with mock.patch('wukong.request.SolrRequest.post') as mock_method:
             fake_response = {
                 "grouped":{
                     "city":{
@@ -186,7 +186,7 @@ class TestSolrAPI(unittest.TestCase):
             self.assertEqual(result['groups']['city']['groups'][0]["doclist"], [])
 
     def test_api_select__group_by(self):
-        with mock.patch('wukong.request.SolrRequest.get') as mock_method:
+        with mock.patch('wukong.request.SolrRequest.post') as mock_method:
             fake_response = {
                 "grouped":{
                     "city":{

--- a/wukong/api.py
+++ b/wukong/api.py
@@ -192,7 +192,7 @@ class SolrAPI(object):
         if kwargs:
             query_dict.update(kwargs)
 
-        response = self.client.get(
+        response = self.client.post(
             self._get_collection_url('select'),
             params=query_dict
         )


### PR DESCRIPTION
## Overview:
Long unicode search strings can cause a request to exceed URI length limits (i.e. http response code 414). For example, a unicode string containing 460 thai characters is url encoded into ~8280 characters which results in a 414 response.

## To Reproduce:
The general issue:
```
>>> import requests

>>> search_query = 'ดี' * 460

>>> resp = requests.get('<solr collection base url>/select', params={"q": search_query})
>>> resp
<Response [414]>
>>> len(resp.url)
8351

>>> resp = requests.post('<solr collection base url>/select', data={"q": search_query})
>>> resp
<Response [200]>
>>> len(resp.url)
68


```
and this can be reproduced by passing the same query string to the /search API wrapper before the PR changes are applied.

## Changes:
* Use POST instead of GET for /select API calls in order to avoid exceeding the max uri length for long queries
* replaced pypy, 2.7, and 3.4 with 3.8 in travis.yml test configs
* added trove classifiers since we specifically only support Python 3.5+
* updated changelog
* bumped major version to 1.0.0