### PR TITLE
search(): _actually_ send the query_dict in the request body

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 
 #Release Notes
 
+1.0.1
+==========
+- search(): _actually_ send the query_dict in the request body as was intended in 1.0.0 (missed a cherry-pick)
+
 1.0.0
 ==========
 - Removed support for Python versions < 3.5 and pypy

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except:
     README = read('README.md')
     CHANGES = read('CHANGES.md')
 
-version = '1.0.0'
+version = '1.0.1'
 
 setup(
     name="wukong",

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -116,7 +116,7 @@ class TestSolrAPI(unittest.TestCase):
 
             assert not mock_method.called
 
-    def test_api_select(self):
+    def test_api_select__with_extra_kwarg(self):
         with mock.patch('wukong.request.SolrRequest.post') as mock_method:
             fake_response = {
                 "response":{
@@ -138,16 +138,16 @@ class TestSolrAPI(unittest.TestCase):
             result = self.api.select(query_dict, extra="extra_value")
             mock_method.assert_called_once_with(
                 'test_collection/select',
-                params={
+                body=json.dumps({'params': {
                     "q":"test_field:test_value",
                     "rows":10,
                     "extra": "extra_value"
-                }
+                }})
             )
             self.assertEqual(result['docs'][0]["pk"], "Test PK")
             self.assertEqual(result['docs'][0]["test_field"], "Test Value")
 
-    def test_api_select__group_by(self):
+    def test_api_select__group_by_with_extra_kwarg(self):
         with mock.patch('wukong.request.SolrRequest.post') as mock_method:
             fake_response = {
                 "grouped":{
@@ -173,19 +173,19 @@ class TestSolrAPI(unittest.TestCase):
             result = self.api.select(query_dict, groups=True, extra="extra_value")
             mock_method.assert_called_once_with(
                 'test_collection/select',
-                params={
+                body=json.dumps({'params': {
                     "q":"test_field:test_value",
                     "rows":10,
                     "group": "on",
                     "group.field": "city",
                     "extra": "extra_value"
-                }
+                }})
             )
 
             self.assertEqual(result['groups']['city']['groups'][0]["groupValue"], 100)
             self.assertEqual(result['groups']['city']['groups'][0]["doclist"], [])
 
-    def test_api_select__group_by(self):
+    def test_api_select__group_by_with_facets(self):
         with mock.patch('wukong.request.SolrRequest.post') as mock_method:
             fake_response = {
                 "grouped":{
@@ -221,14 +221,14 @@ class TestSolrAPI(unittest.TestCase):
             result = self.api.select(query_dict, groups=True, facets=True)
             mock_method.assert_called_once_with(
                 'test_collection/select',
-                params={
+                body=json.dumps({'params': {
                     "q":"test_field:test_value",
                     "rows":10,
                     "group": "on",
                     "group.field": "city",
                     "facet": "on",
                     "facet.field": ["template_ids"]
-                }
+                }})
             )
             self.assertEqual(result['facets']['facet_fields']["template_ids"]["60"], 50)
             self.assertEqual(result['groups']['city']['groups'][0]["groupValue"], 100)

--- a/wukong/api.py
+++ b/wukong/api.py
@@ -194,7 +194,7 @@ class SolrAPI(object):
 
         response = self.client.post(
             self._get_collection_url('select'),
-            params=query_dict
+            body=json.dumps({'params': query_dict})
         )
 
         data = {}


### PR DESCRIPTION
Cleanup from earlier:
* search(): _actually_ send the query_dict in the request body as was intended in v1.0.0 (missed a cherry-pick 🤦 )

I've verified that this indeed fixes the issue for long unicode queries (my bad @dkuang1980)